### PR TITLE
use rspec tests for pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,9 @@ jobs:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           # REDIS_URL: redis://localhost:6379/0
-        run: bin/rails db:test:prepare test test:system
+        run: |
+           bin/rails db:prepare
+           bundle exec rspec --tag '~js'
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,7 +247,7 @@ GEM
     psych (5.2.4)
       date
       stringio
-    public_suffix (6.0.1)
+    public_suffix (6.0.2)
     puma (6.6.0)
       nio4r (~> 2.0)
     raabro (1.4.0)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,9 +14,6 @@ require 'selenium/webdriver'
 require 'devise'
 
 require 'webdrivers'
-# Set the path to the local ChromeDriver
-Selenium::WebDriver::Chrome::Service.driver_path = File.join(Dir.pwd, 'bin', 'chromedriver-linux64', 'chromedriver')
-
 # Initialize Devise
 Devise.setup do |config|
   # Your Devise configuration here
@@ -89,16 +86,25 @@ RSpec.configure do |config|
 
   config.include CsrfHelper, type: :feature
 
-  # Configure Capybara to use Selenium with Chrome
-  Capybara.default_driver = :selenium_chrome_headless
-  Capybara.javascript_driver = :selenium_chrome_headless
+  # Set the default driver for non-JS tests
+  Capybara.default_driver = :rack_test
 
-  # If you want to use the non-headless version of Chrome, use this instead:
-  # Capybara.default_driver = :selenium_chrome
+  # Set the JavaScript driver for JS-enabled tests
+  # Capybara.javascript_driver = :selenium_chrome_headless
 
-  # Ensure that Capybara runs after the Rails app is loaded
-  config.before(:each, type: :system) do
-    driven_by(:selenium_chrome_headless)
+  # Use Selenium only for tests tagged with `:selenium`
+
+  # Conditionally set the ChromeDriver path only for JS tests
+
+
+  config.before(:each, js: true) do
+    Selenium::WebDriver::Chrome::Service.driver_path = File.join(Dir.pwd, 'bin', 'chromedriver-linux64', 'chromedriver')
+    Capybara.current_driver = :selenium_chrome_headless
+  end
+
+  # Reset to the default driver after each test
+  config.after(:each) do
+    Capybara.use_default_driver
   end
 
   # Include FactoryBot methods


### PR DESCRIPTION
Changes the github pipeline to use rspec tests. JS based tests are excluded to avoid use of webdriver in CI for the time being.

The rails helper has been modified to use rack test as the default and only use chromedriver for js tests. 