### PR TITLE
adding erb lint and project rubocop config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,11 @@ jobs:
         with:
           ruby-version: .ruby-version
           bundler-cache: true
-
       - name: Lint code for consistent style
-        run: bin/rubocop -f github
+        run: |
+          set -e
+          bundle exec rubocop --config .rubocop.yml -f github
+          bundle exec erb_lint --config .erb_lint.yml app/views
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
uses project rubocop config for ci rubocop and adds erb lint