### PR TITLE
Initialise play loop

### DIFF
--- a/app/jobs/play_loop_job.rb
+++ b/app/jobs/play_loop_job.rb
@@ -1,0 +1,8 @@
+class PlayLoopJob < ApplicationJob
+  queue_as :default
+
+  def perform(*args)
+    Rails.logger.info "Play loop executed at #{Time.current}"
+    PlayLoopService.new.call(*args)
+  end
+end

--- a/app/jobs/produce_resources_from_building_job.rb
+++ b/app/jobs/produce_resources_from_building_job.rb
@@ -1,0 +1,9 @@
+class ProduceResourcesFromBuildingJob < ApplicationJob
+  queue_as :default
+
+  def perform(building_id, village, multiplier = 1)
+    Rails.logger.info "Producing resources for Building ID: #{building_id} at #{Time.current}"
+    ProduceResourcesFromBuildingService.new(building_id, village, multiplier).call
+    Rails.logger.info "Finished producing resources for Building ID: #{building_id} at #{Time.current}"
+  end
+end

--- a/app/jobs/village_loop_job.rb
+++ b/app/jobs/village_loop_job.rb
@@ -1,0 +1,9 @@
+class VillageLoopJob < ApplicationJob
+  queue_as :default
+
+  def perform(village_id)
+    Rails.logger.info "VillageJob started for Village ID: #{village_id} at #{Time.current}"
+    VillageLoopService.new.call(village_id)
+    Rails.logger.info "VillageJob completed for Village ID: #{village_id} at #{Time.current}"
+  end
+end

--- a/app/models/village_building.rb
+++ b/app/models/village_building.rb
@@ -15,4 +15,8 @@ class VillageBuilding < ApplicationRecord
       village_resource.update(count: village_resource.count - quantity.to_i)
     end
   end
+
+  def has_building_outputs?
+    building.building_outputs.exists?
+  end
 end

--- a/app/services/play_loop_service.rb
+++ b/app/services/play_loop_service.rb
@@ -1,0 +1,11 @@
+class PlayLoopService
+  def call(*args)
+    Rails.logger.info "Play loop service started at #{Time.current}"
+
+    Village.all.each do |village|
+      VillageLoopJob.perform_later(village.id)
+    end
+
+    Rails.logger.info "Play loop service completed at #{Time.current}"
+  end
+end

--- a/app/services/produce_resources_from_building_service.rb
+++ b/app/services/produce_resources_from_building_service.rb
@@ -1,0 +1,25 @@
+class ProduceResourcesFromBuildingService
+  def initialize(building_id, village, multiplier = 1)
+    @building = Building.find(building_id)
+    @multiplier = multiplier
+    @village = village
+  end
+
+  def call
+    Rails.logger.info "Processing Building: #{@building.name}"
+    process_building_outputs
+    Rails.logger.info "Finished processing Building: #{@building.name}"
+  end
+
+  private
+
+  def process_building_outputs
+    @building.building_outputs.each do |output|
+      village_resource = VillageResource.find_or_create_by!(
+        village: @village,
+        resource: output.resource
+      )
+      village_resource.increment!(:count, output.quantity * @multiplier)
+    end
+  end
+end

--- a/app/services/village_loop_service.rb
+++ b/app/services/village_loop_service.rb
@@ -1,0 +1,12 @@
+class VillageLoopService
+  def call(village_id)
+    village = Village.find(village_id)
+
+    Rails.logger.info "Processing Village: #{village.id}"
+    village.village_buildings.select(&:has_building_outputs?).group_by(&:building_id).each do |building_id, village_buildings|
+      ProduceResourcesFromBuildingJob.perform_later(building_id, village, village_buildings.count)
+    end
+
+    Rails.logger.info "Finished processing Village: #{village.id}"
+  end
+end

--- a/db/migrate/20250505130429_add_default_to_village_resource_count.rb
+++ b/db/migrate/20250505130429_add_default_to_village_resource_count.rb
@@ -1,0 +1,5 @@
+class AddDefaultToVillageResourceCount < ActiveRecord::Migration[8.0]
+  def change
+    change_column_default :village_resources, :count, from: nil, to: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_04_121623) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_05_130429) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -92,7 +92,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_04_121623) do
   create_table "village_resources", force: :cascade do |t|
     t.bigint "village_id", null: false
     t.bigint "resource_id", null: false
-    t.integer "count"
+    t.integer "count", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["resource_id"], name: "index_village_resources_on_resource_id"

--- a/spec/jobs/play_loop_job_spec.rb
+++ b/spec/jobs/play_loop_job_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe PlayLoopJob, type: :job do
+  let(:village) { create(:village) }
+  let(:woodcutter) { create(:building, name: "Woodcutter") }
+  let(:farm) { create(:building, name: "Farm") }
+  let(:wood) { create(:resource, name: "Wood") }
+  let(:food) { create(:resource, name: "Food") }
+
+  before do
+    create(:building_output, building: woodcutter, resource: wood, quantity: 1)
+    create(:building_output, building: farm, resource: food, quantity: 1)
+    create(:village_building, village: village, building: woodcutter)
+    create(:village_building, village: village, building: farm)
+
+    allow(VillageLoopJob).to receive(:perform_later).and_wrap_original do |method, *args|
+      VillageLoopJob.perform_now(*args)
+    end
+    allow(ProduceResourcesFromBuildingJob).to receive(:perform_later).and_wrap_original do |method, *args|
+      ProduceResourcesFromBuildingJob.perform_now(*args)
+    end
+  end
+
+  context "when PlayLoopJob is performed" do
+    before { PlayLoopJob.perform_now }
+
+    it "adds the correct amount of wood to the village resources" do
+      expect(village.village_resources.find_by(resource: wood).count).to eq(1)
+    end
+
+    it "adds the correct amount of food to the village resources" do
+      expect(village.village_resources.find_by(resource: food).count).to eq(1)
+    end
+  end
+
+  context "when a building output has a quantity greater than 1" do
+    before do
+      woodcutter.building_outputs.find_by(resource: wood).update(quantity: 3)
+      PlayLoopJob.perform_now
+    end
+
+    it "adds the correct amount of wood to the village resources" do
+      expect(village.village_resources.find_by(resource: wood).count).to eq(3)
+    end
+  end
+
+  context "when there are multiple farms attached to the village" do
+    before do
+      create(:village_building, village: village, building: farm)
+      PlayLoopJob.perform_now
+    end
+
+    it "adds the correct amount of food to the village resources" do
+      expect(village.village_resources.find_by(resource: food).count).to eq(2)
+    end
+  end
+end

--- a/spec/jobs/produce_resources_from_building_job_spec.rb
+++ b/spec/jobs/produce_resources_from_building_job_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe ProduceResourcesFromBuildingJob, type: :job do
+  let(:village) { create(:village) }
+  let(:woodcutter) { create(:building, name: "Woodcutter") }
+  let(:service_instance) { instance_double(ProduceResourcesFromBuildingService) }
+
+  before do
+      allow(ProduceResourcesFromBuildingService).to receive(:new).and_return(service_instance)
+      allow(service_instance).to receive(:call)
+
+      ProduceResourcesFromBuildingJob.perform_now(woodcutter.id, village, 2)
+  end
+  it "calls ProduceResourcesFromBuildingService with the correct parameters" do
+    expect(ProduceResourcesFromBuildingService).to have_received(:new).with(woodcutter.id, village, 2)
+    expect(service_instance).to have_received(:call).once
+  end
+end

--- a/spec/jobs/village_loop_job_spec.rb
+++ b/spec/jobs/village_loop_job_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe VillageLoopJob, type: :job do
+  context "when performing the job" do
+    let(:village) { create(:village) }
+    let(:woodcutter) { create(:building, name: "Woodcutter") }
+    let(:farm) { create(:building, name: "Farm") }
+    let(:service_instance) { instance_double(VillageLoopService) }
+
+    before do
+      create(:village_building, village: village, building: woodcutter)
+      create(:village_building, village: village, building: farm)
+
+      allow(VillageLoopService).to receive(:new).and_return(service_instance)
+      allow(service_instance).to receive(:call)
+    end
+
+    it "calls VillageLoopService with the correct village ID" do
+      VillageLoopJob.perform_now(village.id)
+
+      expect(VillageLoopService).to have_received(:new)
+      expect(service_instance).to have_received(:call).with(village.id)
+    end
+  end
+end

--- a/spec/services/play_loop_service_spec.rb
+++ b/spec/services/play_loop_service_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe PlayLoopService, type: :service do
+  describe "#call" do
+    let!(:village1) { create(:village) }
+    let!(:village2) { create(:village) }
+
+    it "enqueues VillageLoopJob for each village" do
+      # Mock VillageLoopJob
+      allow(VillageLoopJob).to receive(:perform_later)
+
+      # Call the service
+      PlayLoopService.new.call
+
+      # Assert that VillageLoopJob is enqueued for each village
+      expect(VillageLoopJob).to have_received(:perform_later).with(village1.id).once
+      expect(VillageLoopJob).to have_received(:perform_later).with(village2.id).once
+    end
+  end
+end

--- a/spec/services/produce_resources_from_building_service_spec.rb
+++ b/spec/services/produce_resources_from_building_service_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe ProduceResourcesFromBuildingService, type: :service do
+  describe "#call" do
+    let(:village) { create(:village) }
+    let(:woodcutter) { create(:building, name: "Woodcutter") }
+    let!(:logs) { create(:resource, name: "Logs") }
+
+    before do
+      create(:building_output, building: woodcutter, resource: logs, quantity: 5)
+    end
+
+    context "when the village resource already exists" do
+      let!(:village_resource) { create(:village_resource, village: village, resource: logs, count: 10) }
+
+      it "increments the village resource count" do
+        ProduceResourcesFromBuildingService.new(woodcutter.id, village, 2).call
+        expect(village_resource.reload.count).to eq(20) # 10 + (5 * 2)
+      end
+    end
+
+    context "when the village resource does not exist" do
+      it "creates a new village resource with the correct count" do
+        ProduceResourcesFromBuildingService.new(woodcutter.id, village, 1).call
+        village_resource = VillageResource.find_by(village: village, resource: logs)
+
+        expect(village_resource).to have_attributes(count: 5) # 0 + (5 * 1)
+      end
+    end
+  end
+end

--- a/spec/services/village_loop_service_spec.rb
+++ b/spec/services/village_loop_service_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe VillageLoopService, type: :service do
+  describe "#call" do
+    let(:village) { create(:village) }
+    let(:woodcutter) { create(:building, name: "Woodcutter") }
+    let(:farm) { create(:building, name: "Farm") }
+
+    before do
+      # Create village buildings with outputs
+      create(:village_building, village: village, building: woodcutter)
+      create(:village_building, village: village, building: farm)
+
+      # Mock the `has_building_outputs?` method
+      allow_any_instance_of(VillageBuilding).to receive(:has_building_outputs?).and_return(true)
+
+      # Mock ProduceResourcesFromBuildingJob
+      allow(ProduceResourcesFromBuildingJob).to receive(:perform_later)
+
+      VillageLoopService.new.call(village.id)
+    end
+
+    it "enqueues ProduceResourcesFromBuildingJob for each building with the correct parameters" do
+      expect(ProduceResourcesFromBuildingJob).to have_received(:perform_later).with(woodcutter.id, village, 1).once
+      expect(ProduceResourcesFromBuildingJob).to have_received(:perform_later).with(farm.id, village, 1).once
+    end
+  end
+end


### PR DESCRIPTION
Adds a play loop to the app. 

Initially this play loop provokes each village to have it's buildings provoke resources. 

Layers of active jobs and services have been used to keep responsibilities tight and allow for paralelisation, so that the app is scalable with high village and building counts.