### PR TITLE
Fix Selenium Test Failures - ChromeDriver Version Mismatch

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -77,7 +77,7 @@ RSpec.configure do |config|
   # behaviour is considered legacy and will be removed in a future version.
   #
   # To enable this behaviour uncomment the line below.
-  # config.infer_spec_type_from_file_location!
+  config.infer_spec_type_from_file_location!
 
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!


### PR DESCRIPTION
Problem
All JavaScript-enabled feature tests were failing with the following error:

```
Selenium::WebDriver::Error::SessionNotCreatedError:
  session not created: This version of ChromeDriver only supports Chrome version 133
  Current browser version is 138.0.7204.157
```

Root Cause
ChromeDriver version 133.0.6943.141 was installed
Chrome browser version 138.0.7204.157 was running
Version mismatch prevented Selenium from creating browser sessions

Changes Made
1. Updated ChromeDriver Binary
Downloaded ChromeDriver version 138.0.7204.157 to match Chrome browser version
Replaced outdated ChromeDriver in [chromedriver](vscode-file://vscode-app/snap/code/198/usr/share/code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)
Verified version compatibility: ChromeDriver 138.0.7204.157 ↔ Chrome 138.0.7204.157
2. Fixed Asset Cache Permissions
Resolved permission issues with [assets](vscode-file://vscode-app/snap/code/198/usr/share/code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) directory
Recreated cache directory structure with proper permissions
Ensured assets can be compiled during test runs
3. Enhanced RSpec Configuration
Enabled [config.infer_spec_type_from_file_location!](vscode-file://vscode-app/snap/code/198/usr/share/code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) in [rails_helper.rb](vscode-file://vscode-app/snap/code/198/usr/share/code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)
Improved automatic test type detection for system specs